### PR TITLE
Replace serde_cbor with ciborium

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,10 @@ jobs:
         run: cargo test --quiet
       - name: Run tests with Bincode codec
         run: cargo test --no-default-features --quiet --features full --features default-codec-bincode
-      - name: Run tests with CBOR codec
+      - name: Run tests with CBOR (serde_cbor) codec
         run: cargo test --no-default-features --quiet --features full --features default-codec-cbor
+      - name: Run tests with CBOR (ciborium) codec
+        run: cargo test --no-default-features --quiet --features full --features default-codec-ciborium
       - name: Run tests with MessagePack codec
         run: cargo test --no-default-features --quiet --features full --features default-codec-message-pack
       - name: Test rch feature only

--- a/remoc/Cargo.toml
+++ b/remoc/Cargo.toml
@@ -25,7 +25,7 @@ rtc = ["rch", "remoc_macro", "async-trait"]
 default-codec-set = []
 codec-bincode = ["bincode"]
 default-codec-bincode = ["codec-bincode", "default-codec-set"]
-codec-cbor = ["serde_cbor"]
+codec-cbor = ["ciborium"]
 default-codec-cbor = ["codec-cbor", "default-codec-set"]
 codec-json = ["serde_json"]
 default-codec-json = ["codec-json", "default-codec-set"]
@@ -50,7 +50,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # Codecs
 serde_json = { version = "1.0", optional = true }
 bincode = { version = "1.3", optional = true }
-serde_cbor = { version = "0.11", optional = true }
+ciborium = { version = "0.2", optional = true }
 rmp-serde = { version = "0.15", optional = true }
 
 

--- a/remoc/Cargo.toml
+++ b/remoc/Cargo.toml
@@ -25,13 +25,15 @@ rtc = ["rch", "remoc_macro", "async-trait"]
 default-codec-set = []
 codec-bincode = ["bincode"]
 default-codec-bincode = ["codec-bincode", "default-codec-set"]
-codec-cbor = ["ciborium"]
+codec-cbor = ["serde_cbor"]
 default-codec-cbor = ["codec-cbor", "default-codec-set"]
+codec-ciborium = ["ciborium"]
+default-codec-ciborium = ["codec-ciborium", "default-codec-set"]
 codec-json = ["serde_json"]
 default-codec-json = ["codec-json", "default-codec-set"]
 codec-message-pack = ["rmp-serde"]
 default-codec-message-pack = ["codec-message-pack", "default-codec-set"]
-full-codecs = ["codec-bincode", "codec-cbor", "codec-json", "codec-message-pack"]
+full-codecs = ["codec-bincode", "codec-cbor", "codec-ciborium", "codec-json", "codec-message-pack"]
 
 [dependencies]
 remoc_macro = { version = "=0.9.9", path = "../remoc_macro", optional = true }
@@ -50,6 +52,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # Codecs
 serde_json = { version = "1.0", optional = true }
 bincode = { version = "1.3", optional = true }
+serde_cbor = { version = "0.11", optional = true }
 ciborium = { version = "0.2", optional = true }
 rmp-serde = { version = "0.15", optional = true }
 

--- a/remoc/README.md
+++ b/remoc/README.md
@@ -89,7 +89,7 @@ The meta-feature `full` enables all features from above but no codecs.
 The following features enable data formats for transmission:
 
   * `codec-bincode` provides the Bincode format.
-  * `codec-cbor` provides the CBOR format.
+  * `codec-cbor` and `codec-ciborium` provides the CBOR format.
   * `codec-json` provides the JSON format.
   * `codec-message-pack` provides the MessagePack format.
 
@@ -100,6 +100,12 @@ applications, not libraries.
 The feature `full-codecs` enables all codecs.
 
 By default all features are enabled and the JSON codec is used as default.
+
+The `codec-cbor` feature enable CBOR format using [`serde_cbor`], which is
+[no longer maintained]. It is recommended to use `codec-ciborium` instead.
+
+[`serde_cbor`]: https://crates.io/crates/serde_cbor
+[no longer maintained]: https://rustsec.org/advisories/RUSTSEC-2021-0127
 
 
 ## Supported Rust versions

--- a/remoc/src/codec/cbor.rs
+++ b/remoc/src/codec/cbor.rs
@@ -4,7 +4,7 @@ use super::{Codec, DeserializationError, SerializationError};
 
 /// CBOR codec.
 ///
-/// See [serde_cbor] for details.
+/// See [ciborium] for details.
 #[cfg_attr(docsrs, doc(cfg(feature = "codec-cbor")))]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Cbor;
@@ -16,7 +16,7 @@ impl Codec for Cbor {
         Writer: std::io::Write,
         Item: serde::Serialize,
     {
-        serde_cbor::to_writer(writer, item).map_err(SerializationError::new)
+        ciborium::ser::into_writer(item, writer).map_err(SerializationError::new)
     }
 
     #[inline]
@@ -25,6 +25,6 @@ impl Codec for Cbor {
         Reader: std::io::Read,
         Item: serde::de::DeserializeOwned,
     {
-        serde_cbor::from_reader(reader).map_err(DeserializationError::new)
+        ciborium::de::from_reader(reader).map_err(DeserializationError::new)
     }
 }

--- a/remoc/src/codec/cbor.rs
+++ b/remoc/src/codec/cbor.rs
@@ -2,9 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use super::{Codec, DeserializationError, SerializationError};
 
-/// CBOR codec.
+/// CBOR codec using [serde_cbor].
 ///
-/// See [ciborium] for details.
+/// This codec use [serde_cbor] which is [no longer maintained].
+/// It is recommended to use `codec-ciborium` instead.
+///
+/// [no longer maintained]: https://rustsec.org/advisories/RUSTSEC-2021-0127
 #[cfg_attr(docsrs, doc(cfg(feature = "codec-cbor")))]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Cbor;
@@ -16,7 +19,7 @@ impl Codec for Cbor {
         Writer: std::io::Write,
         Item: serde::Serialize,
     {
-        ciborium::ser::into_writer(item, writer).map_err(SerializationError::new)
+        serde_cbor::to_writer(writer, item).map_err(SerializationError::new)
     }
 
     #[inline]
@@ -25,6 +28,6 @@ impl Codec for Cbor {
         Reader: std::io::Read,
         Item: serde::de::DeserializeOwned,
     {
-        ciborium::de::from_reader(reader).map_err(DeserializationError::new)
+        serde_cbor::from_reader(reader).map_err(DeserializationError::new)
     }
 }

--- a/remoc/src/codec/ciborium.rs
+++ b/remoc/src/codec/ciborium.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+use super::{Codec, DeserializationError, SerializationError};
+
+/// CBOR codec using [ciborium].
+///
+/// ## Compatibility
+/// This codec is able to decode values encoded with `codec-cbor`
+/// but the opposite is not true. Make sure you are using `codec-ciborium`
+/// in both client and servers to avoid deserialization errors.
+/// More information in the [`ciborium` README].
+///
+/// [`ciborium` README]: https://github.com/enarx/ciborium#compatibility-with-other-implementations
+#[cfg_attr(docsrs, doc(cfg(feature = "codec-ciborium")))]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Ciborium;
+
+impl Codec for Ciborium {
+    #[inline]
+    fn serialize<Writer, Item>(writer: Writer, item: &Item) -> Result<(), super::SerializationError>
+    where
+        Writer: std::io::Write,
+        Item: serde::Serialize,
+    {
+        ciborium::ser::into_writer(item, writer).map_err(SerializationError::new)
+    }
+
+    #[inline]
+    fn deserialize<Reader, Item>(reader: Reader) -> Result<Item, super::DeserializationError>
+    where
+        Reader: std::io::Read,
+        Item: serde::de::DeserializeOwned,
+    {
+        ciborium::de::from_reader(reader).map_err(DeserializationError::new)
+    }
+}

--- a/remoc/src/codec/mod.rs
+++ b/remoc/src/codec/mod.rs
@@ -24,7 +24,8 @@
 //! The following features select the default codec.
 //!
 //!   * `default-codec-bincode` -- enables and selects Bincode as the default codec
-//!   * `default-codec-cbor` -- enables and selects CBOR as the default codec
+//!   * `default-codec-cbor` -- enables and selects CBOR with `serde_cbor` as the default codec[^serde_cbor]
+//!   * `default-codec-ciborium` -- enables and selects CBOR with `ciborium` as the default codec
 //!   * `default-codec-json` -- enables and selects JSON as the default codec
 //!   * `default-codec-message-pack` -- enables selects MessagePack as the default codec
 //!
@@ -33,6 +34,8 @@
 //! Thus to change the default codec, you must specify `default-features = false` when
 //! referencing Remoc in your `Cargo.toml`.
 //!
+//! [^serde_cbor]: `serde_cbor` is [no longer maintained](https://rustsec.org/advisories/RUSTSEC-2021-0127),
+//!                 it is recommended to use `codec-ciborium` instead.
 
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 use std::{
@@ -177,6 +180,14 @@ pub use cbor::Cbor;
 #[cfg(feature = "default-codec-cbor")]
 #[doc(no_inline)]
 pub use cbor::Cbor as Default;
+
+#[cfg(feature = "codec-ciborium")]
+mod ciborium;
+#[cfg(feature = "codec-ciborium")]
+pub use self::ciborium::Ciborium;
+#[cfg(feature = "default-codec-ciborium")]
+#[doc(no_inline)]
+pub use self::ciborium::Ciborium as Default;
 
 #[cfg(feature = "codec-json")]
 mod json;

--- a/remoc/tests/codec/mod.rs
+++ b/remoc/tests/codec/mod.rs
@@ -92,6 +92,12 @@ fn cbor() {
     roundtrip::<TestStruct, codec::Cbor>()
 }
 
+#[cfg(feature = "codec-ciborium")]
+#[test]
+fn ciborium() {
+    roundtrip::<TestStruct, codec::Ciborium>()
+}
+
 #[cfg(feature = "codec-json")]
 #[test]
 #[should_panic]


### PR DESCRIPTION
`serde_cbor` is no longer maintained since August (see the [repository README](https://github.com/pyfisch/cbor#readme) and [RUSTSEC-2021-0127](https://rustsec.org/advisories/RUSTSEC-2021-0127)). I suggest replacing it with [`ciborium`](https://lib.rs/crates/ciborium) which is actively maintained and recommended by the author of `serde_cbor` as an alternative.

However, `ciborium` has made different design choices that make it incompatible in some cases with `serde_cbor`. This may cause errors if the client and server does not use the same version of remoc.