### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,6 @@
 name: Rust
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,51 +10,163 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  msrv:
+    name: Minimum supported Rust version
+    runs-on: ubuntu-latest
+    env:
+      minrust: 1.51
+    
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Check version dependencies
+        run: ./check_version.sh
+
+      - name: Install Rust ${{ env.minrust }}
+        run: rustup default ${{ env.minrust }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo check
+        run: cargo Check
+  
+  # Lints
+  build-docs:
+    name: Build docs
+    needs: [msrv]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Check version dependencies
-        run: ./check_version.sh
-      - name: Check code formatting
-        run: cargo fmt -- --check
-      - name: Build
-        run: cargo build
-      - name: Build documentation
-        run: cargo doc --no-deps --quiet
-      - name: Code analysis
-        run: cargo clippy --quiet
-      - name: Run tests with JSON (default) codec
-        run: cargo test --quiet
-      - name: Run tests with Bincode codec
-        run: cargo test --no-default-features --quiet --features full --features default-codec-bincode
-      - name: Run tests with CBOR (serde_cbor) codec
-        run: RUSTFLAGS="-A deprecated" cargo test --no-default-features --quiet --features full --features default-codec-cbor
-      - name: Run tests with CBOR (ciborium) codec
-        run: cargo test --no-default-features --quiet --features full --features default-codec-ciborium
-      - name: Run tests with MessagePack codec
-        run: cargo test --no-default-features --quiet --features full --features default-codec-message-pack
-      - name: Test rch feature only
-        run: cargo test --no-default-features --quiet --features rch --features default-codec-json
-      - name: Test rfn feature only
-        run: cargo test --no-default-features --quiet --features rfn --features default-codec-json
-      - name: Test robj feature only
-        run: cargo test --no-default-features --quiet --features robj --features default-codec-json
-      - name: Test rtc feature only
-        run: cargo test --no-default-features --quiet --features rtc --features default-codec-json
-      - name: Test with MSRV 1.51
-        run: |
-          rustup install 1.51
-          cargo +1.51 test --quiet
-      - name: Install Cargo Tarpaulin for code coverage
-        run: cargo install cargo-tarpaulin --locked --quiet
-        continue-on-error: true
-      - name: Code coverage
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Build docs
+        env:
+          RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
+        run: cargo doc --no-deps
+  
+  clippy:
+    name: Clippy
+    needs: [msrv]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run clippy
+        env:
+          RUSTFLAGS: -D warnings
+        run: cargo clippy --tests
+  
+  rustfmt:
+    name: Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+  # Tests
+  test:
+    name: Test
+    needs: [msrv]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo test
+        run: cargo test
+
+  test-codecs:
+    name: Test with codec ${{ matrix.codec }}  
+    needs: [test]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        codec:
+          - bincode
+          - cbor
+          - ciborium
+          - message-pack
+    
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+      
+      - name: Run cargo test
+        env:
+          RUSTFLAGS: -A deprecated
+        run: cargo test --no-default-features --features full --features default-codec-${{ matrix.codec }}
+  
+  test-features:
+    name: Test with ${{ matrix.feature }} only
+    needs: [test]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - rch
+          - rfn
+          - robj
+          - rtc
+    
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+      
+      - name: Run cargo test
+        run: cargo test --no-default-features --features ${{ matrix.feature }} --features default-codec-json
+  
+  # Coverage
+  coverage:
+    name: Coverage
+    needs: [test-codecs, test-features]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      
+      - name: Install cargo tarpaulin
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-tarpaulin
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+      
+      - name: Run cargo tarpaulin
         shell: bash
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           cargo tarpaulin --out Xml
           bash <(curl -s https://codecov.io/bash)
-        continue-on-error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Run cargo check
-        run: cargo Check
+        run: cargo check
   
   # Lints
   build-docs:

--- a/remoc/tests/rch/mpsc.rs
+++ b/remoc/tests/rch/mpsc.rs
@@ -40,10 +40,7 @@ async fn simple() {
     match tx.send(0).await {
         Ok(_) => panic!("send succeeded after close"),
         Err(err)
-            if err.is_closed() && err.is_disconnected() && err.closed_reason() == Some(ClosedReason::Closed) =>
-        {
-            ()
-        }
+            if err.is_closed() && err.is_disconnected() && err.closed_reason() == Some(ClosedReason::Closed) => {}
         Err(_) => panic!("wrong error after close"),
     }
 }
@@ -82,10 +79,7 @@ async fn simple_stream() {
     match tx.send(0).await {
         Ok(_) => panic!("send succeeded after close"),
         Err(err)
-            if err.is_closed() && err.is_disconnected() && err.closed_reason() == Some(ClosedReason::Closed) =>
-        {
-            ()
-        }
+            if err.is_closed() && err.is_disconnected() && err.closed_reason() == Some(ClosedReason::Closed) => {}
         Err(_) => panic!("wrong error after close"),
     }
 }
@@ -128,10 +122,7 @@ async fn simple_close() {
     match tx.send(0).await {
         Ok(_) => panic!("send succeeded after close"),
         Err(err)
-            if err.is_closed() && err.is_disconnected() && err.closed_reason() == Some(ClosedReason::Closed) =>
-        {
-            ()
-        }
+            if err.is_closed() && err.is_disconnected() && err.closed_reason() == Some(ClosedReason::Closed) => {}
         Err(_) => panic!("wrong error after close"),
     }
 }
@@ -172,10 +163,7 @@ async fn simple_drop() {
         Err(err)
             if err.is_disconnected()
                 && !err.is_closed()
-                && err.closed_reason() == Some(ClosedReason::Dropped) =>
-        {
-            ()
-        }
+                && err.closed_reason() == Some(ClosedReason::Dropped) => {}
         Err(_) => panic!("wrong error after close"),
     }
 }
@@ -214,9 +202,7 @@ async fn simple_conn_failure() {
     match tx.send(0).await {
         Ok(_) => panic!("send succeeded after close"),
         Err(err)
-            if err.is_disconnected() && !err.is_closed() && err.closed_reason() == Some(ClosedReason::Failed) =>
-        {
-            ()
+            if err.is_disconnected() && !err.is_closed() && err.closed_reason() == Some(ClosedReason::Failed) => {
         }
         Err(_) => panic!("wrong error after close"),
     }


### PR DESCRIPTION
Hello! I noticed that your current CI workflow takes a lot of time to run. This PR improves it:

- Each step has been separated in different jobs (with matrix jobs for tests). This allows to run task concurrency, and makes the workflow easier to understand.
- Dependencies are cached with [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) and [baptiste0928/cargo-install](https://github.com/baptiste0928/cargo-install) to speed up workflows.
- Clippy is also run on tests (I fixed few lints)

![image](https://user-images.githubusercontent.com/22115890/151025632-271f3329-7a63-4a1c-9c20-3786e985f7f3.png)

With these improvements, the workflow takes only 12 minutes to complete, vs. half an hour with the current one.

This PR contains a lot of useless commits, I suggest you to squash-merge the PR instead of a regular merge.