### PR TITLE
Reduce log level for chmux

### DIFF
--- a/remoc/src/chmux/mux.rs
+++ b/remoc/src/chmux/mux.rs
@@ -624,7 +624,7 @@ where
     ///
     /// The dispatcher terminates when the client, server and all channels have been dropped or
     /// the transport is closed.
-    #[tracing::instrument(name = "remoc::chmux", level = "trace", skip_all, ret)]
+    #[tracing::instrument(name = "remoc::chmux", level = "debug", skip_all, ret)]
     pub async fn run(mut self) -> Result<(), ChMuxError<TransportSinkError, TransportStreamError>> {
         let mut transport_sink = self.transport_sink.take().unwrap();
         let mut transport_stream = self.transport_stream.take().unwrap();

--- a/remoc/src/chmux/mux.rs
+++ b/remoc/src/chmux/mux.rs
@@ -624,7 +624,7 @@ where
     ///
     /// The dispatcher terminates when the client, server and all channels have been dropped or
     /// the transport is closed.
-    #[tracing::instrument(name = "remoc::chmux", level = "info", skip_all, ret)]
+    #[tracing::instrument(name = "remoc::chmux", level = "trace", skip_all, ret)]
     pub async fn run(mut self) -> Result<(), ChMuxError<TransportSinkError, TransportStreamError>> {
         let mut transport_sink = self.transport_sink.take().unwrap();
         let mut transport_stream = self.transport_stream.take().unwrap();


### PR DESCRIPTION
I noticed an info log that was printed in our log file from remoc that looks like a debug or trace message. I think the log level was set to "info" by accident for this.